### PR TITLE
Adding the ability to specify headers in scan requests.

### DIFF
--- a/common/common.py
+++ b/common/common.py
@@ -7,6 +7,18 @@ def normalize_url(i):
     else:
         return ["http://" + i, "https://" + i]
 
+def parse_headers(headers):
+    if headers == None:
+        return None
+    else:
+        parsedheaders = {}
+    
+        for i in headers:
+            header = i.split()
+            header[0] = header[0][:-1]
+            for i in header:
+                parsedheaders[header[0]] = header[1]
+        return parsedheaders
 
 def read_file(input_file):
     lines = linecache.getlines(input_file)

--- a/common/corscheck.py
+++ b/common/corscheck.py
@@ -8,11 +8,14 @@ class CORSCheck:
     """docstring for CORSCheck"""
     url = None
     cfg = None
+    headers = None
 
-    def __init__(self, url, cfg):
+    def __init__(self, url, cfg, headers):
         self.url = url
         self.cfg = cfg
-
+        if headers != None:
+            self.headers = headers
+        
     def send_req(self, url, origin):
         try:
             headers = {
@@ -20,13 +23,12 @@ class CORSCheck:
                 origin,
                 'Cache-Control':
                 'no-cache',
-                'Cookie':
-                'a=b',
                 'User-Agent':
                 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36'
             }
-            resp = requests.get(
-                self.url, timeout=5, headers=headers, allow_redirects=False)
+            if self.headers != None:
+                headers.update(self.headers)
+            resp = requests.get(self.url, timeout=5, headers=headers, allow_redirects=False)
         except Exception, e:
             resp = None
         return resp

--- a/cors_scan.py
+++ b/cors_scan.py
@@ -57,17 +57,18 @@ def parse_args():
         help='Enable Verbosity and display results in realtime',
         nargs='?',
         default=False)
+    parser.add_argument('--headers', help='Add headers to the request.', default=None, nargs='*')
     args = parser.parse_args()
     if not (args.url or args.input):
         parser.error("No url inputed, please add -u or -i option")
     return args
 
 
-def scan(cfg):
+def scan(cfg, headers):
     while not cfg["queue"].empty():
         try:
             item = cfg["queue"].get(timeout=1.0)
-            cors_check = CORSCheck(item, cfg)
+            cors_check = CORSCheck(item, cfg, headers)
             cors_check.check_one_by_one()
         except Exception, e:
             print e
@@ -87,7 +88,7 @@ def main():
     read_urls(args.url, args.input, queue)
 
     print "Start CORS scaning..."
-    threads = [gevent.spawn(scan, cfg) for i in range(args.threads)]
+    threads = [gevent.spawn(scan, cfg, parse_headers(args.headers)) for i in range(args.threads)]
 
     try:
         gevent.joinall(threads)


### PR DESCRIPTION
This pull request adds the ability to specify headers in scan requests. Sometimes you may want to specify some bearer token/etc. in order to authenticate requests, which this will allow you to do.

Proper addition of headers was checked against https://webhook.site/ but feel free to double check.