### PR TITLE
Follow some redirects

### DIFF
--- a/common/corscheck.py
+++ b/common/corscheck.py
@@ -16,6 +16,7 @@ class CORSCheck:
         
     def send_req(self, url, origin):
         try:
+
             headers = {
                 'Origin':
                 origin,
@@ -24,10 +25,12 @@ class CORSCheck:
                 'User-Agent':
                 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36'
             }
+
             if self.headers != None:
                 headers.update(self.headers)
+
             # self-signed cert OK
-            resp = requests.get(self.url, timeout=5, headers=headers, verify=True, allow_redirects=True)
+            resp = requests.get(self.url, timeout=5, headers=headers, verify=False, allow_redirects=True)
 
             # It could be interesting to keep redirects if requesting/requested origins domains are matching
             # (means that a vulnerable origin has been found on the targeted domain/subdomain)
@@ -54,6 +57,7 @@ class CORSCheck:
 
         if resp_headers == None:
             return -1
+        
         # vul_origin does not have to be case sensitive
         if vul_origin.lower() in str(resp_headers.get("access-control-allow-origin")):
             if resp_headers.get("access-control-allow-credentials") == "true":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 gevent
-tld
+tldextract
 argparse
 colorama


### PR DESCRIPTION
Hi back, i totally agree with you, we do not have to follow every redirects. The fact is we can miss some real misconfigurations if we totally block them. Please have a look to ```send_req``` functions. I wrote a  compromise: if the both domains (i mean domains and not fqdn), dealing with the first requested url and the last one (so with code 200), are the same, so it s interesting to check for a misconfiguration.  
  
I tested it. Please let me know what you think. Now if https://domain.com redirects to https://www.domain.com and reflects for example the origin https://evil.com, it will be detected.   
  
Cheers mate.