### PR TITLE
Add shebang to cors_scan.py

### DIFF
--- a/cors_scan.py
+++ b/cors_scan.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import json
 import sys
 import argparse


### PR DESCRIPTION
Since the file cors_scan.py comes as executable, it should begin with the correct python shebang to be properly executed like a standalone executable