### PR TITLE
Move timeout argument into cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Short Form    | Long Form     | Description
 -t            | --threads     | Number of threads to use for CORS scan
 -o            | --output      | Save the results to json file
 -v            | --verbose     | Enable the verbose mode and display results in realtime
--T            | --timeout     | Set requests timeout (default 10 sec)
+-T            | --timeout     | Set requests timeout (default 5 sec)
 -h            | --help        | show the help message and exit
 
 ### Examples

--- a/common/corscheck.py
+++ b/common/corscheck.py
@@ -22,10 +22,10 @@ class CORSCheck:
     timeout = None
     result = {}
 
-    def __init__(self, url, cfg, timeout):
+    def __init__(self, url, cfg):
         self.url = url
         self.cfg = cfg
-        self.timeout = timeout
+        self.timeout = cfg["timeout"]
         self.all_results = []
         if cfg["headers"] != None:
             self.headers = cfg["headers"]


### PR DESCRIPTION
This design will unify our scan(cfg) interface. All options locate in
the cfg structure.

Patch PR #20